### PR TITLE
Some minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
 # couch-pubsub
+
 A pub/sub tool that leverages the power of CouchDB clustering to provide a simple, reliable and distributed system out of the box.
 
 Available on the command line or via the usual Node `require` method.
 
 # Installation 
+
 `couch-pubsub` can be used via the command line or within your Node.js app, it is available on NPM:
 
-```
+
 # via require
+
+```
 npm install couch-pubsub
+```
 
 # via CLI
+
+```
 npm install -g couch-pubsub
 ```
 
 # Usage
+
 You can subscribe or publish to a particular channel.
 
 ## Node
+
 To publish to the `test-channel`, you could do something like this:
+
 ``` js
 var PubSub = require('couch-pubsub');
 
@@ -37,7 +47,14 @@ pubsub.publish("test-channel", "string that you want to publish", function(err, 
 });
 ```
 
+or if you don't want to handle the callback:
+
+``` js
+pubsub.publish("test-channel", "string that you want to publish");
+```
+
 If you wanted to listen for updates to this channel you could do something like this:
+
 ``` js
 var PubSub = require('couch-pubsub');
 
@@ -48,26 +65,29 @@ var pubsub = new PubSub({
   couch_port: null // null for default
 });
 
-var subscribe = pubsub.subscribe("test-channel", function subscribeChannel(channel) {
-
-  channel.on('update', function (update) {
+var sub = pubsub.subscribe("test-channel");
+sub.on('update', function (update) {
     
-    // update - the value that was published (e.g. 'string that you want to publish' from above')
+  // update - the value that was published (e.g. 'string that you want to publish' from above')
     
-  });
-
 });
 ```
 
 ## Command line
+
 To replicate the examples above on the command line you could do:
 
-```
+
 # publish
+
+``` js
 couch-pubsub publish test-channel "string that you want to publish"
 -> {"ok":true,"id":"7d6eaf1ddcd0f8f42f98d4a58ba3a527","rev":"1-9d78b84800709cf0d8446f2147c74d75"}
+```
 
 # subscribe
+
+``` js
 couch-pubsub subscribe test-channel
 -> "string that you want to publish"
 -> "the next string that was published"
@@ -75,13 +95,15 @@ couch-pubsub subscribe test-channel
 ```
 
 You will need to supply your CouchDB credentials via environemnt variables:
+
 ```
-export COUCH_PUBSUB_HOSTNAME="http://my-couch-db.com"
+export COUCH_PUBSUB_HOST="http://my-couch-db.com"
 export COUCH_PUBSUB_USERNAME="username"
 export COUCH_PUBSUB_PASSWORD="password"
 ```
 
 # TODO
+
 I put this together pretty quickly and there are some things I want to add still, such as:
 
 * Retrieving all things published to a channel since <date>

--- a/bin/pubsub.js
+++ b/bin/pubsub.js
@@ -34,17 +34,7 @@ if (action == "publish" && (!argv[4] || argv[4] == "")) {
 
 // load opts from ENV
 if (!process.env.COUCH_PUBSUB_HOST) {
-  console.log("COUCH_PUBSUB_HOST environemtn variable required!");
-  process.exit(1);
-}
-
-if (!process.env.COUCH_PUBSUB_USERNAME) {
-  console.log("COUCH_PUBSUB_USERNAME environemtn variable required!");
-  process.exit(1);
-}
-
-if (!process.env.COUCH_PUBSUB_PASSWORD) {
-  console.log("COUCH_PUBSUB_PASSWORD environemtn variable required!");
+  console.log("COUCH_PUBSUB_HOST environment variable required!");
   process.exit(1);
 }
 
@@ -76,14 +66,12 @@ if (action == "publish") {
 // subscribe
 if (action == "subscribe") {
 
-  subscribe(opts, channel, function CLISubscribe(c) {
-
-    c.on('update', function (update) {
+  var subscription = subscribe(opts, channel);
+  
+  subscription.on('update', function (update) {
+  
+    process.stdout.write(update + "\n");
     
-      process.stdout.write(update + "\n");
-      
-    });
-
   });
 
 }

--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ module.exports = function(opts) {
   }.bind(this);
 
   // Subscribe
-  this.subscribe = function(channel, callback) {
-    subscribe(this.opts, channel, callback);
+  this.subscribe = function(channel) {
+    return subscribe(this.opts, channel);
   }.bind(this);
 
 }

--- a/lib/couchurl.js
+++ b/lib/couchurl.js
@@ -1,0 +1,13 @@
+var url = require('url');
+
+module.exports = function(opts) {
+  var urlObj = url.parse(opts.couch_host);
+  if (opts.couch_username && opts.couch_password) {
+    urlObj.auth = opts.couch_username+":"+opts.couch_password;
+  }
+  if (opts.couch_port) {
+    urlObj.port = opts.couch_port;
+  }
+  urlObj.host = false;
+  return url.format(urlObj)
+}

--- a/lib/pub.js
+++ b/lib/pub.js
@@ -7,17 +7,8 @@ module.exports = function(opts, channel, toPublish, callback) {
   if (typeof opts !== "object" || typeof opts.couch_host !== "string" || opts.couch_host == "") {
     throw new Error("A CouchDB host must be provided");
   }
-
-  // our couch DB url
-  var url = opts.couch_host
-  if (opts.couch_username && opts.couch_password) {
-    url = url.replace("//","//"+opts.couch_username+":"+opts.couch_password+"@");
-  }
   
-  // non-default port?
-  if (opts.couch_port) {
-    url += ":"+opts.couch_port;
-  }
+  var url = require('./couchurl.js')(opts);
 
   // connect to couch
   var nano = require('nano')(url);

--- a/lib/sub.js
+++ b/lib/sub.js
@@ -1,7 +1,11 @@
 var async = require('async');
 
 // Subscribe
-module.exports = function(opts, channel, callback) {
+module.exports = function(opts, channel) {
+
+  // set up our feed
+  var EventEmitter = require('events').EventEmitter;
+  var feed = new EventEmitter();
 
   // required values provided?
   if (typeof opts !== "object" || typeof opts.couch_host !== "string" || opts.couch_host == "") {
@@ -42,10 +46,6 @@ module.exports = function(opts, channel, callback) {
   // subscribe to channel
   actions.subscribe = function(callback) {
 
-    // set up our feed
-    var EventEmitter = require('events').EventEmitter;
-    var feed = new EventEmitter();
-
     // follow changes
     var channel_db = nano.use(channel);
     var changes = channel_db.follow({since: "now", include_docs: true})
@@ -58,10 +58,7 @@ module.exports = function(opts, channel, callback) {
       // if we have the stuff we expect
       // emit this event
       if (typeof change === 'object' && typeof change.doc === 'object' && typeof change.doc.str !== 'undefined') {
-
-        var str = change.doc.str;
-        feed.emit('update', str);
-
+        feed.emit('update', change.doc.str);
       }
 
     });
@@ -73,8 +70,8 @@ module.exports = function(opts, channel, callback) {
 
   async.series(actions, function(err, results) {
 
-    return callback(results.subscribe);
-
   });
+  
+  return feed;
 
 }

--- a/lib/sub.js
+++ b/lib/sub.js
@@ -12,16 +12,7 @@ module.exports = function(opts, channel) {
     throw new Error("A CouchDB host must be provided");
   }
   
-  // our couch DB url
-  var url = opts.couch_host
-  if (opts.couch_username && opts.couch_password) {
-    url = url.replace("//","//"+opts.couch_username+":"+opts.couch_password+"@");
-  }
-  
-  // non-default port?
-  if (opts.couch_port) {
-    url += ":"+opts.couch_port;
-  }
+  var url = require('./couchurl.js')(opts);
 
   // connect to couch
   var nano = require('nano')(url);


### PR DESCRIPTION
1) .subscribe can be a synchronous call, i.e. you can return the EventEmitter straight away. This leaves the user's code to be as simple as

```
var sub = pubsub.subscribe("test-channel")
  .on('update', function (update) {
     // update - the value that was published (e.g. 'string that you want to publish' from above')
  });
```

2) moved the url parsing logic to a separate js file to avoid repetition an to use the `url` library instead of joining bits of url components together with strings

3) change the command-line tool and documentation to suit 
